### PR TITLE
rpc.c: read enhanced ikonos tags

### DIFF
--- a/c/rpc.c
+++ b/c/rpc.c
@@ -82,6 +82,10 @@ static void add_tag_to_rpc(struct rpc *p, char *tag, double x)
 	else if (0 <= (t=pix(tag, "iSAMP_DEN_COEFF_"))) p->idenx  [t] = x;
 	else if (0 <= (t=pix(tag, "iLINE_NUM_COEFF_"))) p->inumy  [t] = x;
 	else if (0 <= (t=pix(tag, "iLINE_DEN_COEFF_"))) p->ideny  [t] = x;
+	else if (0 <= (t=pix(tag, "LON_NUM_COEFF_")))   p->inumx  [t] = x;
+	else if (0 <= (t=pix(tag, "LON_DEN_COEFF_")))   p->idenx  [t] = x;
+	else if (0 <= (t=pix(tag, "LAT_NUM_COEFF_")))   p->inumy  [t] = x;
+	else if (0 <= (t=pix(tag, "LAT_DEN_COEFF_")))   p->ideny  [t] = x;
 	else if (0 == strhas(tag, "FIRST_ROW"))         p->dmval  [1] = x;
 	else if (0 == strhas(tag, "FIRST_COL"))         p->dmval  [0] = x;
 	else if (0 == strhas(tag, "LAST_ROW"))          p->dmval  [3] = x;


### PR DESCRIPTION
This adds support for reading complete ikonos rpc tags in rpc.c, which is included in disp_to_h, which is called by triangulation.py.  The rpc are not currently read by the C code, but passed to it through a ctype, but still.

Note that  if the inverse ikonos model is not read, the triangulation will be very slow because it will solve two nested iterative inversions per point (about 100=10x10 RPC evaluations in total).